### PR TITLE
Add support for deleting stream messages after ACK

### DIFF
--- a/lib/redis.client.ts
+++ b/lib/redis.client.ts
@@ -412,6 +412,13 @@ export class RedisStreamClient extends ClientProxy {
         inboundContext.getMessageId(),
       );
 
+      if (true === this.options?.streams?.deleteMessagesAfterAck) {
+        await this.client.xdel(
+          inboundContext.getStream(),
+          inboundContext.getMessageId(),
+        );
+      }
+
       return true;
     } catch (error) {
       this.logger.error(error);


### PR DESCRIPTION
This pull request fixes the functionality where stream messages are not being deleted after acknowledgment (ACK). We added a condition to check if the option `deleteMessagesAfterAck` is true. If it is, the message will be deleted from the stream immediately after it has been acknowledged. This change ensures that the stream data is managed correctly and prevents unnecessary accumulation of messages.

---

> This pull request was co-created with Cosine Genie

Original Task: [nestjs-redis-streams/qfhfrrs4677r](https://cosine.sh/pandelis/nestjs-redis-streams/task/qfhfrrs4677r)
Author: Pandelis Zembashis
